### PR TITLE
v0.3.3: Enterprise support, connection testing, roadmap

### DIFF
--- a/.github/skills/gh-devlake-roadmap/SKILL.md
+++ b/.github/skills/gh-devlake-roadmap/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: gh-devlake-roadmap
+description: Look up the gh-devlake CLI roadmap, milestones, issues, version plans, and release priorities. Use when the user asks about roadmap, priorities, what's planned, what version something is in, or what issues exist for a milestone.
+---
+
+# gh-devlake Roadmap Lookup
+
+## Repository
+
+- **Owner:** DevExpGBB
+- **Repo:** gh-devlake
+- **Project Board:** https://github.com/orgs/DevExpGbb/projects/21 (Project #21)
+- **Milestones URL:** https://github.com/DevExpGBB/gh-devlake/milestones
+
+## How to Look Up Roadmap Information
+
+Use the GitHub MCP tools to query issues and milestones from `DevExpGBB/gh-devlake`.
+
+### List milestones and their issues
+
+Use `mcp_github_list_issues` with the repo `DevExpGBB/gh-devlake` to get issues.
+Filter by milestone name to see what's in each release.
+
+To find all milestones, use the `gh` CLI:
+```
+gh api repos/DevExpGBB/gh-devlake/milestones --jq '.[] | "\(.title): \(.description) (\(.open_issues) open, \(.closed_issues) closed)"'
+```
+
+To find issues for a specific milestone:
+```
+gh issue list --repo DevExpGBB/gh-devlake --milestone "v0.3.4" --json number,title,state,labels
+```
+
+### Issue labels
+
+| Label | Meaning |
+|-------|---------|
+| `enhancement` | New feature or request |
+| `bug` | Something isn't working |
+| `refactor` | Code restructure, no behavior change |
+| `documentation` | Docs, skills, instructions |
+
+## Versioning Scheme
+
+Semantic versioning: `MAJOR.MINOR.PATCH`
+
+- **0.3.x** — Current development line. Incremental features, restructuring, and lifecycle commands.
+  - PATCH bumps for features that don't change the CLI's plugin surface area (same set of supported DevOps tools).
+- **0.4.x** — Multi-tool expansion. New plugin types (GitLab, Azure DevOps) that expand the CLI's supported tool surface.
+- **MINOR bumps** only when genuinely new categories of capability arrive (new DevOps tool plugins, new token resolution chains).
+- **MAJOR bump (1.0)** — Reserved for production-ready stability declaration.
+
+## Current Release Plan
+
+| Version | Theme | Status |
+|---------|-------|--------|
+| v0.3.3 | Enterprise Support | In progress — scope ID fix, connection testing, rate limit, enterprise threading |
+| v0.3.4 | CLI Restructure | Planned — singular commands, --plugin flag, list command, CLI versioning |
+| v0.3.5 | Connection Lifecycle | Planned — delete and test commands |
+| v0.3.6 | Connection Update + Skill | Planned — update command, this roadmap skill |
+| v0.4.0 | Multi-Tool Expansion | Future — GitLab, Azure DevOps, per-plugin token chains |
+
+## CLI Command Architecture (Option A)
+
+Connection lifecycle commands live under `configure connection`:
+```
+gh devlake configure connection create  --plugin gh-copilot ...
+gh devlake configure connection delete  --plugin gh-copilot --id 2
+gh devlake configure connection update  --plugin gh-copilot --id 2 --token ghp_new
+gh devlake configure connection list
+gh devlake configure connection test    --plugin gh-copilot --id 2
+```
+
+Each command operates on one plugin at a time. Interactive mode prompts for plugin selection.
+
+## Key Design Decisions
+
+1. **One plugin per invocation** in flag mode. Interactive mode walks through plugins sequentially.
+2. **`--plugin` flag** replaces `--skip-copilot`/`--skip-github` (positive selection, not negative exclusion).
+3. **Singular command names** (`connection`, `scope`, `project`) — not plurals.
+4. **Delete/update/test are subcommands**, not flags — each is a distinct action with distinct UX.
+5. **Plugin-specific fields** (org, enterprise, repos) are validated per-plugin, not shared across all.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,17 @@ internal/
 - **Discovery chain**: explicit `--url` → state file → well-known ports
 - **Generic API helpers**: `doPost[T]`, `doGet[T]`, `doPut[T]`, `doPatch[T]` in `internal/devlake/client.go`
 
+### Plugin System
+Plugins are defined via `ConnectionDef` structs in `cmd/connection_types.go`. Each entry declares the plugin slug, endpoint, required fields (`NeedsOrg`, `NeedsEnterprise`), and PAT scopes. To add a new DevOps tool, add a `ConnectionDef` to `connectionRegistry` — no other registration needed.
+
+**One plugin per invocation.** Flag-based commands target a single `--plugin`. Interactive mode walks through plugins sequentially. This keeps plugin-specific fields (org, enterprise, repos, tokens) self-contained.
+
+### Copilot Scope ID Convention
+The `gh-copilot` plugin computes scope IDs as: enterprise + org → `"enterprise/org"`, enterprise only → `"enterprise"`, org only → `"org"`. See `copilotScopeID()` in `cmd/configure_scopes.go`. The scope ID must match the plugin's `listGhCopilotRemoteScopes` logic exactly or blueprint references will break.
+
+## Roadmap
+See `.github/skills/gh-devlake-roadmap/SKILL.md` for version plan, milestones, and design decisions. Project board: https://github.com/orgs/DevExpGbb/projects/21
+
 ## Terminal Output & UX — CRITICAL
 
 **The terminal IS the UI.** Every `fmt.Print` call is a UX decision. Readability, rhythm, and breathing room are non-negotiable.

--- a/cmd/configure_full.go
+++ b/cmd/configure_full.go
@@ -109,10 +109,16 @@ func runConfigureFull(cmd *cobra.Command, args []string) error {
 		case "gh-copilot":
 			scopeCopilotConnID = r.ConnectionID
 			scopeSkipCopilot = false
+			if scopeEnterprise == "" && r.Enterprise != "" {
+				scopeEnterprise = r.Enterprise
+			}
 		}
 	}
 	if fullOrg != "" {
 		scopeOrg = fullOrg
+	}
+	if fullEnterprise != "" {
+		scopeEnterprise = fullEnterprise
 	}
 	cfgURL = devlakeURL
 

--- a/cmd/configure_scopes_test.go
+++ b/cmd/configure_scopes_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import "testing"
+
+func TestCopilotScopeID(t *testing.T) {
+	tests := []struct {
+		name       string
+		org        string
+		enterprise string
+		want       string
+	}{
+		{
+			name: "org only",
+			org:  "my-org",
+			want: "my-org",
+		},
+		{
+			name:       "enterprise and org",
+			org:        "my-org",
+			enterprise: "my-enterprise",
+			want:       "my-enterprise/my-org",
+		},
+		{
+			name:       "enterprise only",
+			enterprise: "my-enterprise",
+			want:       "my-enterprise",
+		},
+		{
+			name:       "enterprise with whitespace-only org",
+			org:        "   ",
+			enterprise: "my-enterprise",
+			want:       "my-enterprise",
+		},
+		{
+			name:       "whitespace-only enterprise falls back to org",
+			org:        "my-org",
+			enterprise: "   ",
+			want:       "my-org",
+		},
+		{
+			name:       "both with leading/trailing spaces",
+			org:        "  my-org  ",
+			enterprise: "  my-ent  ",
+			want:       "my-ent/my-org",
+		},
+		{
+			name: "both empty",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := copilotScopeID(tt.org, tt.enterprise)
+			if got != tt.want {
+				t.Errorf("copilotScopeID(%q, %q) = %q, want %q", tt.org, tt.enterprise, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/connection_types.go
+++ b/cmd/connection_types.go
@@ -53,13 +53,17 @@ func (d *ConnectionDef) BuildCreateRequest(name string, params ConnectionParams)
 	if params.Endpoint != "" {
 		endpoint = params.Endpoint
 	}
+	rateLimitPerHour := 4500
+	if d.Plugin == "gh-copilot" {
+		rateLimitPerHour = 5000
+	}
 	req := &devlake.ConnectionCreateRequest{
 		Name:             name,
 		Endpoint:         endpoint,
 		Proxy:            params.Proxy,
 		AuthMethod:       "AccessToken",
 		Token:            params.Token,
-		RateLimitPerHour: 4500,
+		RateLimitPerHour: rateLimitPerHour,
 	}
 	if d.Plugin == "github" {
 		req.EnableGraphql = true
@@ -79,15 +83,25 @@ func (d *ConnectionDef) BuildTestRequest(params ConnectionParams) *devlake.Conne
 	if params.Endpoint != "" {
 		endpoint = params.Endpoint
 	}
+	rateLimitPerHour := 4500
+	if d.Plugin == "gh-copilot" {
+		rateLimitPerHour = 5000
+	}
 	req := &devlake.ConnectionTestRequest{
 		Endpoint:         endpoint,
 		AuthMethod:       "AccessToken",
 		Token:            params.Token,
-		RateLimitPerHour: 4500,
+		RateLimitPerHour: rateLimitPerHour,
 		Proxy:            params.Proxy,
 	}
 	if d.Plugin == "github" {
 		req.EnableGraphql = true
+	}
+	if d.NeedsOrg && params.Org != "" {
+		req.Organization = params.Org
+	}
+	if d.NeedsEnterprise && params.Enterprise != "" {
+		req.Enterprise = params.Enterprise
 	}
 	return req
 }
@@ -110,6 +124,7 @@ var connectionRegistry = []*ConnectionDef{
 		Endpoint:        "https://api.github.com/",
 		NeedsOrg:        true,
 		NeedsEnterprise: true,
+		SupportsTest:    true,
 		RequiredScopes:  []string{"manage_billing:copilot", "read:org"},
 		ScopeHint:       "manage_billing:copilot, read:org (+ read:enterprise for enterprise metrics)",
 	},

--- a/cmd/connection_types_test.go
+++ b/cmd/connection_types_test.go
@@ -1,0 +1,124 @@
+package cmd
+
+import "testing"
+
+func TestBuildCreateRequest_RateLimit(t *testing.T) {
+	tests := []struct {
+		name     string
+		plugin   string
+		wantRate int
+	}{
+		{"github uses 4500", "github", 4500},
+		{"gh-copilot uses 5000", "gh-copilot", 5000},
+		{"unknown uses 4500", "gitlab", 4500},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := &ConnectionDef{Plugin: tt.plugin, Endpoint: "https://api.github.com/"}
+			req := def.BuildCreateRequest("test", ConnectionParams{Token: "tok"})
+			if req.RateLimitPerHour != tt.wantRate {
+				t.Errorf("got rate limit %d, want %d", req.RateLimitPerHour, tt.wantRate)
+			}
+		})
+	}
+}
+
+func TestBuildCreateRequest_EnterpriseOrg(t *testing.T) {
+	def := &ConnectionDef{
+		Plugin:          "gh-copilot",
+		Endpoint:        "https://api.github.com/",
+		NeedsOrg:        true,
+		NeedsEnterprise: true,
+	}
+
+	t.Run("org and enterprise", func(t *testing.T) {
+		req := def.BuildCreateRequest("test", ConnectionParams{
+			Token:      "tok",
+			Org:        "my-org",
+			Enterprise: "my-ent",
+		})
+		if req.Organization != "my-org" {
+			t.Errorf("got Organization %q, want %q", req.Organization, "my-org")
+		}
+		if req.Enterprise != "my-ent" {
+			t.Errorf("got Enterprise %q, want %q", req.Enterprise, "my-ent")
+		}
+	})
+
+	t.Run("org only", func(t *testing.T) {
+		req := def.BuildCreateRequest("test", ConnectionParams{
+			Token: "tok",
+			Org:   "my-org",
+		})
+		if req.Organization != "my-org" {
+			t.Errorf("got Organization %q, want %q", req.Organization, "my-org")
+		}
+		if req.Enterprise != "" {
+			t.Errorf("got Enterprise %q, want empty", req.Enterprise)
+		}
+	})
+
+	t.Run("enterprise only", func(t *testing.T) {
+		req := def.BuildCreateRequest("test", ConnectionParams{
+			Token:      "tok",
+			Enterprise: "my-ent",
+		})
+		if req.Organization != "" {
+			t.Errorf("got Organization %q, want empty", req.Organization)
+		}
+		if req.Enterprise != "my-ent" {
+			t.Errorf("got Enterprise %q, want %q", req.Enterprise, "my-ent")
+		}
+	})
+}
+
+func TestBuildTestRequest_CopilotFields(t *testing.T) {
+	def := &ConnectionDef{
+		Plugin:          "gh-copilot",
+		Endpoint:        "https://api.github.com/",
+		NeedsOrg:        true,
+		NeedsEnterprise: true,
+	}
+
+	t.Run("includes org and enterprise", func(t *testing.T) {
+		req := def.BuildTestRequest(ConnectionParams{
+			Token:      "tok",
+			Org:        "my-org",
+			Enterprise: "my-ent",
+		})
+		if req.Organization != "my-org" {
+			t.Errorf("got Organization %q, want %q", req.Organization, "my-org")
+		}
+		if req.Enterprise != "my-ent" {
+			t.Errorf("got Enterprise %q, want %q", req.Enterprise, "my-ent")
+		}
+		if req.RateLimitPerHour != 5000 {
+			t.Errorf("got rate limit %d, want 5000", req.RateLimitPerHour)
+		}
+	})
+
+	t.Run("github does not include org/enterprise", func(t *testing.T) {
+		ghDef := &ConnectionDef{
+			Plugin:       "github",
+			Endpoint:     "https://api.github.com/",
+			SupportsTest: true,
+		}
+		req := ghDef.BuildTestRequest(ConnectionParams{
+			Token:      "tok",
+			Org:        "ignored",
+			Enterprise: "ignored",
+		})
+		if req.Organization != "" {
+			t.Errorf("github test request should not have Organization, got %q", req.Organization)
+		}
+		if req.Enterprise != "" {
+			t.Errorf("github test request should not have Enterprise, got %q", req.Enterprise)
+		}
+		if req.RateLimitPerHour != 4500 {
+			t.Errorf("got rate limit %d, want 4500", req.RateLimitPerHour)
+		}
+		if !req.EnableGraphql {
+			t.Error("github test request should have EnableGraphql=true")
+		}
+	})
+}

--- a/internal/devlake/client.go
+++ b/internal/devlake/client.go
@@ -41,8 +41,10 @@ func (c *Client) Ping() error {
 
 // Connection represents a DevLake plugin connection.
 type Connection struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	ID           int    `json:"id"`
+	Name         string `json:"name"`
+	Organization string `json:"organization,omitempty"`
+	Enterprise   string `json:"enterprise,omitempty"`
 }
 
 // ConnectionCreateRequest is the payload for creating a GitHub or Copilot connection.
@@ -68,6 +70,8 @@ type ConnectionTestRequest struct {
 	EnableGraphql    bool   `json:"enableGraphql,omitempty"`
 	RateLimitPerHour int    `json:"rateLimitPerHour"`
 	Proxy            string `json:"proxy"`
+	Organization     string `json:"organization,omitempty"`
+	Enterprise       string `json:"enterprise,omitempty"`
 }
 
 // ConnectionTestResult is the response from testing a connection.

--- a/internal/devlake/types.go
+++ b/internal/devlake/types.go
@@ -29,11 +29,12 @@ type GitHubRepoScope struct {
 	ScopeConfigID int    `json:"scopeConfigId,omitempty"`
 }
 
-// CopilotScope represents a Copilot organization scope entry.
+// CopilotScope represents a Copilot organization or enterprise scope entry.
 type CopilotScope struct {
 	ID           string `json:"id"`
 	ConnectionID int    `json:"connectionId"`
 	Organization string `json:"organization"`
+	Enterprise   string `json:"enterprise,omitempty"`
 	Name         string `json:"name"`
 	FullName     string `json:"fullName"`
 }


### PR DESCRIPTION
## Changes

### Enterprise Scope ID Fix (#1)
- `copilotScopeID(org, enterprise)` computes scope IDs matching the plugin convention
- enterprise + org -> `enterprise/org`, enterprise only -> `enterprise`, org only -> `org`
- `putCopilotScope` and `scopeCopilot` updated to accept and pass enterprise
- `--enterprise` flag added to scopes, projects, and full commands
- Enterprise auto-resolved from state file when flag is omitted

### Connection Testing (#2)
- `SupportsTest: true` enabled for gh-copilot in connectionRegistry
- org/enterprise included in test request payload
- Connections tested before creation -- bad tokens caught early

### Rate Limit (#3)
- Copilot connections now use 5000 (plugin default) instead of 4500

### Connection Struct (#4)
- `Organization` and `Enterprise` fields added to `Connection` struct
- Enterprise carried through `connChoice` and `discoverConnections`

### Roadmap & Docs
- `AGENTS.md`: Plugin system, scope ID convention, roadmap pointer
- `.github/skills/gh-devlake-roadmap/SKILL.md`: Versioning scheme, milestones, design decisions

### Tests
- 7 test cases for `copilotScopeID` (edge cases: whitespace, empty, combinations)
- 8 test cases for `BuildCreateRequest`/`BuildTestRequest` (rate limits, org/enterprise)

Closes #1, closes #2, closes #3, closes #4
