### PR TITLE
fix: v0.3.7 quick wins (9 issues)

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -128,6 +128,10 @@ func runAzureCleanup() error {
 		return fmt.Errorf("invalid state file: %w", err)
 	}
 
+	if state.ResourceGroup == "" {
+		return fmt.Errorf("state file %s has no resource group — nothing to clean up.\nIf this is a local deployment, use --local instead", stateFile)
+	}
+
 	fmt.Printf("\nDeployment found:\n")
 	fmt.Printf("  Deployed:       %s\n", state.DeployedAt)
 	fmt.Printf("  Resource Group: %s\n", state.ResourceGroup)

--- a/cmd/configure_connections.go
+++ b/cmd/configure_connections.go
@@ -99,9 +99,6 @@ func runConfigureConnections(cmd *cobra.Command, args []string) error {
 
 	// ── Create connection ──
 	fmt.Printf("\n📡 Creating %s connection...\n", def.DisplayName)
-	if def.ScopeHint != "" {
-		fmt.Printf("   Required PAT scopes: %s\n", def.ScopeHint)
-	}
 	params := ConnectionParams{
 		Token:      tokResult.Token,
 		Org:        org,
@@ -126,7 +123,7 @@ func runConfigureConnections(cmd *cobra.Command, args []string) error {
 	}
 	replaced := false
 	for i, c := range state.Connections {
-		if c.Plugin == def.Plugin {
+		if c.Plugin == def.Plugin && c.ConnectionID == newConn.ConnectionID {
 			state.Connections[i] = newConn
 			replaced = true
 			break

--- a/cmd/configure_full.go
+++ b/cmd/configure_full.go
@@ -188,9 +188,6 @@ func runConnectionsInternal(defs []*ConnectionDef, org, enterprise, tokenVal, en
 	var results []ConnSetupResult
 	for _, def := range defs {
 		fmt.Printf("\n📡 Creating %s connection...\n", def.DisplayName)
-		if def.ScopeHint != "" {
-			fmt.Printf("   Required PAT scopes: %s\n", def.ScopeHint)
-		}
 		params := ConnectionParams{
 			Token:      tokResult.Token,
 			Org:        org,

--- a/cmd/configure_projects.go
+++ b/cmd/configure_projects.go
@@ -157,43 +157,38 @@ func runConfigureProjects(cmd *cobra.Command, args []string) error {
 			break
 		}
 
-		// Auto-add if only one connection exists and nothing added yet
 		var picked connChoice
-		if len(remaining) == 1 && len(added) == 0 {
-			picked = remaining[0]
-			fmt.Printf("\n📡 One connection available — adding %s automatically.\n", picked.label)
-		} else {
-			// Show what's been added so far
-			if len(added) > 0 {
-				fmt.Println()
-				fmt.Println("   " + strings.Repeat("─", 44))
-				fmt.Println("   Added so far:")
-				for _, a := range added {
-					fmt.Printf("     ✅ %s\n", a.summary)
-				}
-				fmt.Println("   " + strings.Repeat("─", 44))
-			}
 
+		// Show what's been added so far
+		if len(added) > 0 {
 			fmt.Println()
-			fmt.Println("   Choose a connection to add to this project.")
-			fmt.Println()
-
-			labels := make([]string, len(remaining))
-			for i, c := range remaining {
-				labels[i] = c.label
+			fmt.Println("   " + strings.Repeat("─", 44))
+			fmt.Println("   Added so far:")
+			for _, a := range added {
+				fmt.Printf("     ✅ %s\n", a.summary)
 			}
-			chosen := prompt.Select("Add connection", labels)
-			if chosen == "" {
-				if len(added) == 0 {
-					return fmt.Errorf("at least one connection is required")
-				}
+			fmt.Println("   " + strings.Repeat("─", 44))
+		}
+
+		fmt.Println()
+		fmt.Println("   Choose a connection to add to this project.")
+		fmt.Println()
+
+		labels := make([]string, len(remaining))
+		for i, c := range remaining {
+			labels[i] = c.label
+		}
+		chosen := prompt.Select("Add connection", labels)
+		if chosen == "" {
+			if len(added) == 0 {
+				return fmt.Errorf("at least one connection is required")
+			}
+			break
+		}
+		for _, c := range remaining {
+			if c.label == chosen {
+				picked = c
 				break
-			}
-			for _, c := range remaining {
-				if c.label == chosen {
-					picked = c
-					break
-				}
 			}
 		}
 

--- a/cmd/connection_types.go
+++ b/cmd/connection_types.go
@@ -218,6 +218,7 @@ func buildAndCreateConnection(client *devlake.Client, def *ConnectionDef, params
 	}
 
 	if def.SupportsTest {
+		fmt.Println("   🔑 Testing connection...")
 		testReq := def.BuildTestRequest(params)
 		testResult, err := client.TestConnection(def.Plugin, testReq)
 		if err != nil {

--- a/internal/devlake/client.go
+++ b/internal/devlake/client.go
@@ -21,7 +21,7 @@ func NewClient(baseURL string) *Client {
 	return &Client{
 		BaseURL: baseURL,
 		HTTPClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: 90 * time.Second,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Independent bug fixes and improvements for v0.3.7. No architectural changes — those come in PR2 (scope/project separation).

## Changes

| Issue | Fix | File |
|-------|-----|------|
| #31 | Validate empty resourceGroup before Azure cleanup | `cmd/cleanup.go` |
| #32 | Remove duplicate PAT scope printing in connection creation | `cmd/configure_connections.go` |
| #33 | Add "Testing connection..." message before test API call | `cmd/connection_types.go` |
| #34 | Increase HTTP client timeout from 30s to 90s | `internal/devlake/client.go` |
| #36 | Remove auto-connection pickup, always show interactive picker | `cmd/configure_projects.go` |
| #43 | Warn when state file URL found but backend is unreachable | `internal/devlake/discovery.go` |
| #44 | Replace duplicate `stateFile` struct with `LoadState()` | `internal/devlake/discovery.go` |
| #47 | Fix state dedup to use plugin+connectionID (not plugin alone) | `cmd/configure_connections.go` |
| #48 | Remove duplicate PAT scope printing in configure full | `cmd/configure_full.go` |

## Testing

- `go build` — clean
- `go test ./...` — only pre-existing failure in `TestRunConfigureScopes_PluginFlag` (#45, global state mutation). No new failures.

Closes #31, #32, #33, #34, #36, #43, #44, #47, #48