### PR TITLE
fix: handle nested scope objects in ListScopes API response

### DIFF
--- a/cmd/configure_projects.go
+++ b/cmd/configure_projects.go
@@ -284,20 +284,30 @@ if err != nil {
 return nil, fmt.Errorf("could not list scopes: %w", err)
 }
 if resp == nil || len(resp.Scopes) == 0 {
-return nil, fmt.Errorf("no scopes found on connection %d", c.id)
+return nil, fmt.Errorf("no scopes found on connection %d \u2014 run 'gh devlake configure scope' first", c.id)
 }
 
 var bpScopes []devlake.BlueprintScope
 var repos []string
-for _, s := range resp.Scopes {
+for _, w := range resp.Scopes {
+s := w.Scope
+// Resolve scope ID: GitHub uses githubId (int), Copilot uses id (string)
+scopeID := s.ID
+if c.plugin == "github" && s.GithubID > 0 {
+scopeID = fmt.Sprintf("%d", s.GithubID)
+}
+scopeName := s.FullName
+if scopeName == "" {
+scopeName = s.Name
+}
 bpScopes = append(bpScopes, devlake.BlueprintScope{
-ScopeID:   s.ScopeID,
-ScopeName: s.ScopeName,
+ScopeID:   scopeID,
+ScopeName: scopeName,
 })
 if c.plugin == "github" && s.FullName != "" {
 repos = append(repos, s.FullName)
 }
-fmt.Printf("   %s (ID: %s)\n", s.ScopeName, s.ScopeID)
+fmt.Printf("   %s (ID: %s)\n", scopeName, scopeID)
 }
 fmt.Printf("   \u2705 Found %d scope(s)\n", len(bpScopes))
 

--- a/internal/devlake/types.go
+++ b/internal/devlake/types.go
@@ -44,18 +44,26 @@ type ScopeBatchRequest struct {
 	Data []any `json:"data"`
 }
 
-// ScopeListEntry represents a scope entry returned by GET /scopes.
-// Fields are the common subset across plugins; plugin-specific fields are ignored.
+// ScopeListWrapper wraps a scope object as returned by the DevLake GET scopes API.
+// The API nests each scope inside a "scope" key: { "scope": { ... } }.
+type ScopeListWrapper struct {
+	Scope ScopeListEntry `json:"scope"`
+}
+
+// ScopeListEntry represents a scope object returned inside the wrapper.
+// ID fields vary by plugin (githubId for GitHub, id for Copilot), so we
+// capture both and resolve in the caller.
 type ScopeListEntry struct {
-	ScopeID   string `json:"scopeId"`
-	ScopeName string `json:"scopeName"`
-	FullName  string `json:"fullName,omitempty"`
+	GithubID int    `json:"githubId,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Name     string `json:"name"`
+	FullName string `json:"fullName,omitempty"`
 }
 
 // ScopeListResponse is the response from GET /plugins/{plugin}/connections/{id}/scopes.
 type ScopeListResponse struct {
-	Scopes []ScopeListEntry `json:"scopes"`
-	Count  int              `json:"count"`
+	Scopes []ScopeListWrapper `json:"scopes"`
+	Count  int                `json:"count"`
 }
 
 // Project represents a DevLake project.


### PR DESCRIPTION
Bug found during live testing: the DevLake `GET /scopes` API returns scopes wrapped in a nested `scope` key, not flat `scopeId`/`scopeName` fields.

**Before:** `ScopeListEntry` expected `{ scopeId, scopeName }` - parsed as empty.
**After:** `ScopeListWrapper.Scope` handles `{ scope: { githubId, id, fullName } }` correctly.

Tested against a real DevLake instance with 231 GitHub scopes and 1 Copilot scope.